### PR TITLE
chore: changed package name, and bumped version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@aoeu/eslint-config-aoeu",
-  "version": "0.1.0",
+  "name": "@aoeu/eslint-config",
+  "version": "0.2.0",
   "description": "Custom ESLint configuration for The Art of Education University",
   "main": "index.js",
   "repository": "git@github.com:theartofeducation/eslint-config-aoeu.git",


### PR DESCRIPTION
So, the way I had this setup before, it required consuming packages eslint config files to be setup like this:

```
module.exports = {
  extends: [
    "@aoeu/aoeu",
    "@aoeu/aoeu/react",
    "@aoeu/aoeu/testing"
  ]
}
```

That is gross. So, I checked in on the documentation. This change will allow us to update that to be easier to read and reason about, like this:

```
module.exports = {
  extends: [
    "@aoeu",
    "@aoeu/react",
    "@aoeu/testing"
  ]
}
```
