### PR TITLE
chore: add react/jsx self-closing-comp rule definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoeu/eslint-config",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Custom ESLint configuration for The Art of Education University",
   "main": "index.js",
   "repository": "git@github.com:theartofeducation/eslint-config-aoeu.git",

--- a/rules/react-jsx.js
+++ b/rules/react-jsx.js
@@ -1,6 +1,10 @@
 module.exports = {
   rules: {
     "react/jsx-closing-bracket-location": ["error", "after-props"],
+    "react/self-closing-comp": ["error", {
+      "component": true,
+      "html": true
+    }],
     "react/react-in-jsx-scope": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": [


### PR DESCRIPTION
This PR adds a rule to our react/jsx configuration for the `eslint-plugin-react` rule: [`self-closing-comp`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md). I've noticed this a handful of places in our code, and I feel like we should be using self-closing tags where they are practical. Doing so will help keep our code consistent with a little less unnecessary noise, and enforcing the rule here will help with that.