### PR TITLE
fix: per the eslint docs, added plugins as peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ This package provides an extensible [shared configuration](https://eslint.org/do
 ## Installation
 
 ```
-yarn add -D @aoeu/eslint-config
+yarn add -D eslint @aoeu/eslint-config @babel/eslint-plugin eslint-plugin-import eslint-plugin-jest eslint-plugin-jsx-a11y eslint-plugin-mdx eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-testcafe
 ```
 
 Or, with npm:
 
 ```
-npm install -D @aoeu/eslint-config
+npm install -D eslint @aoeu/eslint-config @babel/eslint-plugin eslint-plugin-import eslint-plugin-jest eslint-plugin-jsx-a11y eslint-plugin-mdx eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-testcafe
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoeu/eslint-config",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Custom ESLint configuration for The Art of Education University",
   "main": "index.js",
   "repository": "git@github.com:theartofeducation/eslint-config-aoeu.git",
@@ -22,6 +22,16 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-testcafe": "^0.2.1",
     "husky": "^6.0.0"
+  },
+  "peerDependencies": {
+    "@babel/eslint-plugin": "^7.13.16",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-jest": "^24.3.5",
+    "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-mdx": "^1.12.0",
+    "eslint-plugin-react": "^7.23.2",
+    "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-testcafe": "^0.2.1"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
https://eslint.org/docs/developer-guide/shareable-configs

"If your shareable config depends on a plugin, you should also specify it as a peerDependency (plugins will be loaded relative to the end user's project, so the end user is required to install the plugins they need). However, if your shareable config depends on a third-party parser or another shareable config, you can specify these packages as dependencies."