### PR TITLE
chore: added new rules for import order and component props new lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoeu/eslint-config",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Custom ESLint configuration for The Art of Education University",
   "main": "index.js",
   "repository": "git@github.com:theartofeducation/eslint-config-aoeu.git",

--- a/rules/ecmascript.js
+++ b/rules/ecmascript.js
@@ -20,6 +20,14 @@ module.exports = {
     "global-require": "warn",
     "import/no-dynamic-require": "warn",
     "import/no-extraneous-dependencies": "off",
+    "import/order": ["error", {
+      "groups": ["builtin", "external", "internal", "parent", "sibling", "object", "type", "unknown"],
+      "alphabetize": {
+        "order": "asc",
+        "caseInsensitive": true
+      },
+      "newlines-between": "never"
+    }],
     "no-console": "off",
     "no-multi-assign": "off",
     "no-multiple-empty-lines": ["error", { max: 1, maxEOF: 0 }],

--- a/rules/react-jsx.js
+++ b/rules/react-jsx.js
@@ -5,6 +5,10 @@ module.exports = {
       "component": true,
       "html": true
     }],
+    "react/jsx-max-props-per-line": ["error", {
+      "maximum": 2,
+      "when": "always"
+    }],
     "react/react-in-jsx-scope": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": [


### PR DESCRIPTION
Added new rules to our configuration for the following scenarios/code:

* React component props: only allow a max of 2 per line
* Module `import` statements, enforce order
