### PR TITLE
fix: fixed import-order rule configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoeu/eslint-config",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Custom ESLint configuration for The Art of Education University",
   "main": "index.js",
   "repository": "git@github.com:theartofeducation/eslint-config-aoeu.git",

--- a/rules/ecmascript.js
+++ b/rules/ecmascript.js
@@ -22,6 +22,29 @@ module.exports = {
     "import/no-extraneous-dependencies": "off",
     "import/order": ["error", {
       "groups": ["builtin", "external", "internal", "parent", "sibling", "object", "type", "unknown"],
+      "pathGroups": [
+        {
+          "pattern": "@/**",
+          "group": "internal"
+        },
+        {
+          "pattern": "@mui/**",
+          "group": "external"
+        },
+        {
+          "pattern": "@mui-icons/**",
+          "group": "external"
+        },
+        {
+          "pattern": "@mui-lab/**",
+          "group": "external"
+        },
+        {
+          "pattern": "@mui-picker/**",
+          "group": "external"
+        }
+      ],
+      "pathGroupsExcludedImportTypes": ["react"],
       "alphabetize": {
         "order": "asc",
         "caseInsensitive": true


### PR DESCRIPTION
This PR fixes the configuration of our import-order rule configuration to consider our custom babel import aliases.