### PR TITLE
fix: fixed jsx-max-props-per-line rule config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoeu/eslint-config",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Custom ESLint configuration for The Art of Education University",
   "main": "index.js",
   "repository": "git@github.com:theartofeducation/eslint-config-aoeu.git",

--- a/rules/react-jsx.js
+++ b/rules/react-jsx.js
@@ -6,8 +6,8 @@ module.exports = {
       "html": true
     }],
     "react/jsx-max-props-per-line": ["error", {
-      "maximum": 2,
-      "when": "always"
+      "maximum": 3,
+      "when": "multiline"
     }],
     "react/react-in-jsx-scope": "off",
     "react-hooks/rules-of-hooks": "error",


### PR DESCRIPTION
This PR fixes our configuration for the eslint-plugin-react/jsx-max-props-per-line rule.